### PR TITLE
Fix java.util.ConcurrentModificationException + add 1.10 "support"

### DIFF
--- a/src/fr/vinetos/frp/ForceResourcePack.java
+++ b/src/fr/vinetos/frp/ForceResourcePack.java
@@ -22,8 +22,8 @@ public class ForceResourcePack extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        if(!Bukkit.getVersion().contains("1.8") && !Bukkit.getVersion().contains("1.9") ){
-            System.out.println("[ForceResourcePack] The plugin work only on a 1.8.X-1.9.x version.");
+        if(!Bukkit.getVersion().contains("1.8") && !Bukkit.getVersion().contains("1.9") && !Bukkit.getVersion().contains("1.10") ){
+            System.out.println("[ForceResourcePack] The plugin work only on a 1.8.X-1.10.x version.");
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
@@ -42,8 +42,9 @@ public class ForceResourcePack extends JavaPlugin {
         task = Bukkit.getScheduler().scheduleSyncRepeatingTask(getInstance(), new Runnable() {
             @Override
             public void run() {
-                //
-                for(Player p : getPlayers2().keySet()){
+                Player[] players = getPlayers2().keySet().toArray(new Player[0]);
+            	
+                for(Player p : players){
                     if(System.currentTimeMillis() - getPlayers2().get(p) >= 2000){
                         p.setResourcePack(ForceResourcePack.getConfigUtils().getJoinPack());
                         getPlayers2().remove(p);


### PR DESCRIPTION
Fixed this error:
> `[Server thread/WARN]: [ForceResourcePack] Task #2187440 for ForceResourcePack v3.0.3 generated an exception
java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429) ~[?:1.8.0_45]
        at java.util.HashMap$KeyIterator.next(HashMap.java:1453) ~[?:1.8.0_45]
        at fr.vinetos.frp.ForceResourcePack$1.run(ForceResourcePack.java:50) ~[?:?]
        at org.bukkit.craftbukkit.v1_10_R1.scheduler.CraftTask.run(CraftTask.java:58) ~[patched_1.10.jar:git-Paper-798]
        at org.bukkit.craftbukkit.v1_10_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:352) [patched_1.10.jar:git-Paper-798]
        at net.minecraft.server.v1_10_R1.MinecraftServer.D(MinecraftServer.java:802) [patched_1.10.jar:git-Paper-798]
        at net.minecraft.server.v1_10_R1.DedicatedServer.D(DedicatedServer.java:403) [patched_1.10.jar:git-Paper-798]
        at net.minecraft.server.v1_10_R1.MinecraftServer.C(MinecraftServer.java:730) [patched_1.10.jar:git-Paper-798]
        at net.minecraft.server.v1_10_R1.MinecraftServer.run(MinecraftServer.java:629) [patched_1.10.jar:git-Paper-798]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_45]`

I used a intermediate array containing players.